### PR TITLE
Add serialization method

### DIFF
--- a/lib/CustomVError.js
+++ b/lib/CustomVError.js
@@ -63,6 +63,19 @@ class CustomVError extends VError {
 
 		return `${this._message} ${infoString}`;
 	}
+
+	toJSON() {
+		let json = {
+			name: this.name,
+			message: this.message
+		};
+
+		if (this.code) {
+			json.code = this.code;
+		}
+
+		return json;
+	}
 }
 
 module.exports = CustomVError;

--- a/test/CustomError.spec.js
+++ b/test/CustomError.spec.js
@@ -65,4 +65,14 @@ describe('CustomVError', function () {
 			expect(error instanceof Error).to.eq(true);
 		}
 	});
+
+	it('serializes name, message and code', function () {
+		try {
+			throw new TestError();
+		} catch (error) {
+			expect(JSON.stringify(error)).to.eql('{"name":"TestError","message":"Test message"}');
+			error.code = 123;
+			expect(JSON.stringify(error)).to.eql('{"name":"TestError","message":"Test message","code":123}');
+		}
+	});
 });


### PR DESCRIPTION
Adding this will make `res.json(err)` calls to produce a clean output instead of serializing bunch of private properties like:

```json
    {
      "jse_shortmsg": "",
      "jse_info": {},
      "_message": "Bad Password",
      "name": "PasswordError",
      "code": 403
    }
```